### PR TITLE
Remove ad-hoc expected value correction needed for `predict.glmmTMB()` hurdle model problem

### DIFF
--- a/02-grand-RRS/03-bootstrap-best-model.R
+++ b/02-grand-RRS/03-bootstrap-best-model.R
@@ -15,16 +15,10 @@ predict_model = function(fit) {
   # build data frame for prediction: individual years, all combos of covariates
   pred_data = make_pred_data()
   
-  # obtain negative binomial parameters at each combo of prediction covariates
-  mu  = predict(fit, pred_data, type = "cond")  # mu parameter of truncated_nbinom2
-  phi = predict(fit, pred_data, type = "disp")  # phi parameter of truncated_nbinom2
-  pi  = predict(fit, pred_data, type = "zprob") # probability of not crossing hurdle
-  
-  # obtain the expected values from the model at each combo of prediction covariates
-  # these account for the truncation when calculating the expected value
-  pred_data$resp  = sapply(1:nrow(pred_data), function(i) get_expected_resp(mu[i], phi[i], pi[i]))
-  pred_data$cond  = sapply(1:nrow(pred_data), function(i) get_expected_cond(mu[i], phi[i]))
-  pred_data$nzprb = 1 - pi
+  # obtain expected values at each combo of prediction covariates
+  pred_data$cond  = predict(fit, pred_data, type = "conditional")  # conditional mean: expected value of all non-zero counts
+  pred_data$resp  = predict(fit, pred_data, type = "response")  # response mean: expected value of all counts
+  pred_data$nzprb = 1 - predict(fit, pred_data, type = "zprob") # probability of crossing hurdle
   
   # convert to long format across prediction types
   pred_data = reshape2::melt(pred_data, id.vars = c("year", "origin"))
@@ -58,7 +52,7 @@ my_cluster = snow::makeSOCKcluster(ncpus)
 snow::clusterEvalQ(my_cluster, {library("lme4"); library("glmmTMB")})
 
 # send the necessary objects to the cluster
-snow::clusterExport(my_cluster, c("fit", "predict_model", "make_pred_data", "dnbinom2", "dtnbinom2", "get_expected_resp", "get_expected_cond", "dat"))
+snow::clusterExport(my_cluster, c("fit", "predict_model", "make_pred_data", "dat"))
 
 # run the bootstrap
 boot_out = lme4::bootMer(fit, FUN = function(x) predict_model(x)$out, nsim = nboot,

--- a/03-cross-types/cross-type-analysis.R
+++ b/03-cross-types/cross-type-analysis.R
@@ -75,9 +75,7 @@ simfit = function(fit) {
   if (is.character(new_fit)) {
     return(rep(NA, nrow(make_pred_data(fit))))
   } else {
-    mu = predict(new_fit, newdata = make_pred_data(fit), type = "cond")
-    phi = predict(new_fit, newdata = make_pred_data(fit), type = "disp")
-    pred = sapply(1:length(mu), function(i) get_expected_resp(mu[i], phi[i], 0))
+    pred = predict(new_fit, newdata = make_pred_data(fit), type = "response")
     return(pred)
   }
 }
@@ -94,9 +92,7 @@ stoptime = Sys.time()
 stoptime - starttime
 
 # obtain the fitted values for original non-bootstrapped data
-mu = predict(best_mod, newdata = make_pred_data(best_mod), type = "cond")
-phi = predict(best_mod, newdata = make_pred_data(best_mod), type = "disp")
-original_ests = sapply(1:length(mu), function(i) get_expected_resp(mu[i], phi[i], 0))
+original_ests = predict(best_mod, newdata = make_pred_data(best_mod), type = "response")
 boot_preds = cbind(original_ests, boot_preds)
 
 # assign iteration names; original dataset is iter_0

--- a/README.md
+++ b/README.md
@@ -33,25 +33,31 @@ All analyses that use random number generators (e.g., parametric bootstrapping) 
 
 ## Dependencies
 
-All GL(M)M analyses were conducted in R (v4.0.2). Many R packages were used, listed below in general order of their centrality to our analysis (i.e., core model fitting/diagnostics packages listed before general-purpose data preparation packages):
+All GL(M)M analyses were conducted in R (v4.0.2). Many R packages were used, listed below in general order of their centrality to our analysis (i.e., core model fitting/diagnostics packages listed before general-purpose data preparation packages).
+
+> The original code for analysis as published (tagged as [v1.0](https://github.com/bstaton1/LKG-RRS/releases/tag/v1.0) and archived under DOI: [10.5281/zenodo.7278182](https://10.5281/zenodo.7278182)) used `glmmTMB` v1.0.2.1, which contained a bug when obtaining conditional (and as a result, response) expected values for hurdle models (see [#634](https://github.com/glmmTMB/glmmTMB/issues/634) for the original mention in the developers' issue tracker); we independently discovered the same issue when undertaking the analysis for the manuscript and we implemented an ad-hoc fix to prevent this from affecting our results.
+>
+> However, since publication, `glmmTMB` has been updated on CRAN (to v1.1.5 at time of writing) and the bug no longer exists, but the (now unnecessary) fix we implemented for the old version gives the wrong inference with `glmmTMB` >= v1.1.5.  Please see [here](https://gist.github.com/bstaton1/9c745315797bef59c0107e0426e38bee) for a complete description of the bug that was present in the old version in the context of our analysis, the solution we implemented to ensure valid inference at the time of publication, and an illustration that the fix we implemented is no longer needed with `glmmTMB` >=v1.1.5.
+>
+> **This version of the analysis code has the ad-hoc fix removed, thus, it is of critical importance that you use `glmmTMB` >= v1.1.5 to reproduce our results. This version has been tested with R v4.2.2 and the listed versions of the below packages and completely replicates the results published in the article.**
 
 | Package Name | Version Used | Purpose                                                      |
 | ------------ | ------------ | ------------------------------------------------------------ |
-| `glmmTMB`    | 1.0.2.1      | Fitting of GL(M)Ms                                           |
-| `MuMIn`      | 1.43.17      | Model selection tasks                                        |
-| `DHARMa`     | 0.3.3.0      | Model assumption diagnostics                                 |
-| `lme4`       | 1.1.23       | Parametric bootstrapping via `lme4::boot.mer()`              |
-| `emmeans`    | 1.7.2        | Performing multiple comparisons                              |
-| `parallel`   | 4.0.2        | Parallel processing                                          |
-| `snow`       | 0.4.3        | Parallel processing                                          |
-| `stringr`    | 1.4.0        | Character string manipulations                               |
+| `glmmTMB`    | 1.1.5        | Fitting of GL(M)Ms                                           |
+| `MuMIn`      | 1.47.1       | Model selection tasks                                        |
+| `DHARMa`     | 0.4.6        | Model assumption diagnostics                                 |
+| `lme4`       | 1.1.31       | Parametric bootstrapping via `lme4::boot.mer()`              |
+| `emmeans`    | 1.8.3        | Performing multiple comparisons                              |
+| `parallel`   | 4.2.2        | Parallel processing                                          |
+| `snow`       | 0.4.4        | Parallel processing                                          |
+| `stringr`    | 1.5.0        | Character string manipulations                               |
 | `reshape2`   | 1.4.4        | Data reformatting, e.g., from long to wide                   |
 | `abind`      | 1.4.5        | Creating higher-dimensional arrays from lower-dimensional arrays |
-| `lubridate`  | 1.7.9        | Handling dates                                               |
-| `dplyr`      | 1.0.0        | Summarizing large output data frames                         |
-| `bookdown`   | 0.20         | R markdown output formats that include cross references      |
-| `knitr`      | 1.29         | Rendering R markdown files                                   |
-| `kableExtra` | 1.3.4.9000   | Formatting of tables generated with `knitr::kable()`         |
-| `details`    | 0.2.1        | Creating collapsible output in R markdown                    |
-| `scales`     | 1.1.1        | Creating transparent colors                                  |
+| `lubridate`  | 1.9.0        | Handling dates                                               |
+| `dplyr`      | 1.0.10       | Summarizing large output data frames                         |
+| `bookdown`   | 0.31         | R markdown output formats that include cross references      |
+| `knitr`      | 1.41         | Rendering R markdown files                                   |
+| `kableExtra` | 1.3.4        | Formatting of tables generated with `knitr::kable()`         |
+| `details`    | 0.3          | Creating collapsible output in R markdown                    |
+| `scales`     | 1.2.1        | Creating transparent colors                                  |
 

--- a/common-functions.R
+++ b/common-functions.R
@@ -133,39 +133,6 @@ diag_resids = function(resids, return_pvals = TRUE) {
   }
 }
 
-##### FUNCTIONS FOR CALCULATING EXPECTED VALUES THAT ACCOUNT FOR ZERO-TRUNCATION #####
-
-# probability mass function for glmmTMB::nbinom2
-# https://mc-stan.org/docs/2_20/functions-reference/nbalt.html
-# variance the same as described in glmmTMB::nbinom2 family description
-# x: a random variable, should be an integer
-# mu: the expected value of the negative binomial distribution
-# phi: the overdispersion parameter of the negative binomial distribution
-dnbinom2 = function(x, mu, phi) {
-  choose(x + phi - 1, x) * (mu/(mu + phi))^x * (phi/(mu + phi))^phi
-}
-
-# probability mass function for glmmTMB::truncated_nbinom2
-dtnbinom2 = function(x, mu, phi) {
-  ifelse(x == 0, {
-    0
-  }, {
-    dnbinom2(x, mu, phi)/(1 - dnbinom2(0, mu, phi))
-  }) 
-}
-
-# obtain E(y) for all y (including y == 0 and y > 0)
-get_expected_resp = function(mu, phi, zprob) {
-  x_vals = 0:1000
-  sum(dtnbinom2(x_vals, mu, phi) * x_vals) * (1 - zprob)
-}
-
-# obtain E(y) for only y > 0
-get_expected_cond = function(mu, phi) {
-  x_vals = 1:1000
-  sum(dtnbinom2(x_vals, mu, phi) * x_vals)
-}
-
 # obtain the names of all of these objects so they are not removed later
 custom_fn_names = ls()
 


### PR DESCRIPTION
This PR introduces a change necessary to keep this analysis current with an updated version of a critical R package: `glmmTMB`. `glmmTMB` v.1.0.2.1 was used when developing the analysis, however we independently discovered an already-known bug ([#634](https://github.com/glmmTMB/glmmTMB/issues/634)) and included an ad-hoc fix in our analysis for publication to ensure our results were unaffected. However now `glmmTMB` has been updated (to v1.1.5 on CRAN at time of writing), this bug has been officially fixed, rendering our ad-hoc fix unnecessary and troublesome. 

Complete details on this topic can be found [here](https://gist.github.com/bstaton1/9c745315797bef59c0107e0426e38bee), but a synopsis is provided below.

### The Bug

`predict(fit, type = "conditional")` for a hurdle model should produce the expected value for non-zero counts. However, we discovered (as did the author of [#634](https://github.com/glmmTMB/glmmTMB/issues/634)) that (as of v1.0.2.1) it instead returned the `mu` parameter of the `truncated_dnbinom2` distribution -- due to the zero-truncation, the `mu` parameter and the expected value are not the same. Thus, the conditional mean was underestimated as was the value obtained using `predict(fit, type = "response")`, since this is simply the conditional mean multiplied by the probability of crossing the hurdle. Standard negative binomial and zero-inflated negative binomial models were unaffected because the `mu` parameter is actually the conditional mean in these cases.

### Our Fix

We desired the expected value, not the `mu` parameter. So we took the sum product of all possible values of the random variable (from 1 to 1,000, suitable for our case where the majority of counts were less than 10) and their probability mass based on the `mu` parameter obtained from `predict()`, the dispersion parameter obtained from `sigma(fit)`, and the zero truncated negative binomial probability mass function. 

### The Official Fix

Since `glmmTMB` v1.1.5, `predict(fit, type = "conditional")` and `predict(fit, type = "response")` now work as expected: they produce the expected value -- please see [here](https://gist.github.com/bstaton1/9c745315797bef59c0107e0426e38bee) for a verification of this.

### Why is this PR Necessary?

Because `glmmTMB` v1.1.5 now returns the correct output, our ad-hoc correction now gives incorrect estimates. This PR simply removes our now unnecessary ad-hoc fix.

### Does this PR Reproduce the Publication Results?

Yes, the code was tested using R v4.2.2 with `glmmTMB` v1.1.5 and the other package versions listed in the README and was found to reproduce the results presented in the publication.